### PR TITLE
Update German translation

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -32,7 +32,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/virt-manager/virt-manager/issues\n"
 "POT-Creation-Date: 2022-02-27 06:15+0000\n"
 "PO-Revision-Date: 2022-08-01 13:19+0000\n"
-"Last-Translator: Ettore Atalan <atalanttore@googlemail.com>\n"
+"Last-Translator: Florian H. <postfuerflo@gmail.com>\n"
 "Language-Team: German <https://translate.fedoraproject.org/projects/"
 "virt-manager/virt-manager/de/>\n"
 "Language: de\n"
@@ -144,7 +144,7 @@ msgstr "_Gerätemodell:"
 
 #: ui/addhardware.ui:673 ui/addhardware.ui:1229
 msgid "Host _Device:"
-msgstr "_Wirtsgerät:"
+msgstr "_Hostrechner:"
 
 #: ui/addhardware.ui:749
 msgid "_Path:"
@@ -292,7 +292,7 @@ msgstr "Vorhandener Datenträger"
 
 #: ui/clone.ui:222
 msgid "Create a new disk (c_lone) for the virtual machine"
-msgstr "Neuen Datenträger erzeugen (k_lonen) für die virtuelle Maschine"
+msgstr "Neuen Datenträger für die virtuelle Maschine erzeugen (k_lonen)"
 
 #: ui/clone.ui:256 ui/createvol.ui:404 ui/fsdetails.ui:63
 msgid "_Browse..."


### PR DESCRIPTION
Minor changes.
"Wirt*s*gerät" is misspelled but also the wrong German word for "host".